### PR TITLE
[Fix] Ability to write spaces in the Moniker

### DIFF
--- a/installer/installer.py
+++ b/installer/installer.py
@@ -929,7 +929,7 @@ class Interviewer:
         answer = self.ask(
             f"Provide a moniker for your cheqd-node", default=platform.node())
         if answer is not None:
-            self.moniker = answer
+            self.moniker = answer if answer.find(' ') == -1 else '\"' + answer + '\"'
         else:
             failure_exit(f"Invalid moniker provided during cheqd-noded setup.")
 


### PR DESCRIPTION
If there are spaces in the moniker, then it is replaced with the same enclosed in quotes